### PR TITLE
Adding visCollapse Example on #83

### DIFF
--- a/inst/shiny/src/server/proxy_options_server.R
+++ b/inst/shiny/src/server/proxy_options_server.R
@@ -47,6 +47,11 @@ observe({
 
 observe({
   visNetworkProxy("network_proxy_options") %>%
+    visCollapse(nodes = input$nodes_to_collapse)
+})
+
+observe({
+  visNetworkProxy("network_proxy_options") %>%
     visOptions(collapse = list(enabled = input$collapse, fit = input$fit_collapse, resetHighlight = input$reset_collapse))
 })
 

--- a/inst/shiny/src/ui/proxy_options_ui.R
+++ b/inst/shiny/src/ui/proxy_options_ui.R
@@ -15,6 +15,7 @@ shiny::tabPanel(
       sliderInput("opasel", "Opacity selection :", min = 0, max = 1, value = 0.5),
       hr(),
       checkboxInput("collapse", "Enable collapse", FALSE),
+      textInput("nodes_to_collapse","List of nodes to collapse: use format c(4,5)"),
       checkboxInput("fit_collapse", "Fit after collapse", FALSE),
       checkboxInput("reset_collapse", "Reset highlight after collapse", FALSE),
       checkboxInput("open_collapse", "Enable open cluster", FALSE)


### PR DESCRIPTION
Trying to play around with the VisCollapse... was attempting to pass a vector via `c(1,2)`, but it doesn't seem to work. If you try just passing ONE id: for example 4,5 it will work... but the vector no?