### PR TITLE
Set the specified margin to nodes in visNodes

### DIFF
--- a/R/visNodes.R
+++ b/R/visNodes.R
@@ -198,6 +198,7 @@ visNodes <- function(graph,
   nodes$icon <- icon
   nodes$shadow <- shadow
   nodes$shapeProperties <- shapeProperties
+  nodes$margin <- margin
   nodes$chosen <- chosen
   nodes$widthConstraint <- widthConstraint
   nodes$heightConstraint <- heightConstraint


### PR DESCRIPTION
Currently `margin` argument is ignored in `visNodes` function. This PR will fix it.