### PR TITLE
Clear pop up and re-draw edit buttons after cancel

### DIFF
--- a/inst/htmlwidgets/visNetwork.js
+++ b/inst/htmlwidgets/visNetwork.js
@@ -2872,6 +2872,8 @@ HTMLWidgets.widget({
               var r = confirm("Do you want to delete " + data.nodes.length + " node(s) and " + data.edges.length + " edges ?");
               if (r === true) {
                 deleteSubGraph(data, callback);
+              } else {
+                cancelEdit(callback);
               }
           };
         } else {
@@ -2896,6 +2898,8 @@ HTMLWidgets.widget({
               var r = confirm("Do you want to delete " + data.edges.length + " edges ?");
               if (r === true) {
                 deleteSubGraph(data, callback);
+              } else {
+                cancelEdit(callback);
               }
           };
         } else {

--- a/inst/htmlwidgets/visNetwork.js
+++ b/inst/htmlwidgets/visNetwork.js
@@ -2862,6 +2862,8 @@ HTMLWidgets.widget({
             var r = confirm("Do you want to delete " + data.nodes.length + " node(s) and " + data.edges.length + " edges ?");
             if (r === true) {
               deleteSubGraph(data, callback);
+            } else {
+              cancelEdit(callback);
             }
         };
       } else if(typeof(x.options.manipulation.deleteNode) === typeof(true)){
@@ -2884,6 +2886,8 @@ HTMLWidgets.widget({
             var r = confirm("Do you want to delete " + data.edges.length + " edges ?");
             if (r === true) {
               deleteSubGraph(data, callback);
+            } else {
+              cancelEdit(callback);
             }
         };
       } else if(typeof(x.options.manipulation.deleteEdge) === typeof(true)){


### PR DESCRIPTION
I believe this should solve #325. Have checked the code for any disruptions this may cause, couldn't find any but of course this is first time I had a look at source code for `visNetwork`, so these changes would need to be reviewed carefully. Have tested the functionality and it seems to work now.