### PR TITLE
visTree: Make .generateYColor robust towards NaN and degenerate trees

### DIFF
--- a/R/visTree.R
+++ b/R/visTree.R
@@ -779,9 +779,9 @@ subsetRpart <- function(tree,data,  node = 1L) {
     vardecidedClust <- round(object$frame$yval, digits)
     
     # palette
-    if(length(row.names(object$frame)) > 1){
-      meanV <- object$frame$yval-min(object$frame$yval)
-      meanV <- meanV/max(meanV)
+    if (length(unique(na.omit(object$frame$yval))) > 1) {
+      meanV <- object$frame$yval - min(object$frame$yval, na.rm = TRUE)
+      meanV <- meanV/max(meanV, na.rm = TRUE)
     } else {
       meanV <- 1
     }


### PR DESCRIPTION
Make color ramp generation robust against two degenerate cases:

   1. Presence of NaN values in `object$frame$yval`. 
   2. Duplicated values of `object$frame$yval` which might result in yval range in a tree being 0 which results in division by 0 in [this line](https://github.com/datastorm-open/visNetwork/blob/30bb79b726a8862133b857e09c3b7b60076e68e9/R/visTree.R#L784).

Both cases can occur in trees which were refit to new data. That is, `yval` values and node counts are recomputed on new data but preserving the tree structure. Unfortunately there is no built in functionality for such a "refit" in rpart, so I have my own custom code for that. Thus cannot provide a simple repro. But hopefully the PR is simple enough not to require that. 

An example of such a tree:

```
n= 2944 

node), split, n, deviance, yval
      * denotes terminal node

1) root 2944 1940000000 257  
  2) var< 2.17e+03 2944  278000000 257 *
  3) var>=2.17e+03 0 1640000000 NaN *
```