### PR TITLE
enable tests to be run post-install

### DIFF
--- a/inst/tests/highlight_combinaison.R
+++ b/inst/tests/highlight_combinaison.R
@@ -1,3 +1,5 @@
+require(visNetwork)
+
 # simple nodes, passing some information individually
 nodes <- data.frame(id = 1:5, color = c("blue", NA, "green", NA, NA))
 

--- a/inst/tests/understand_coordinates.R
+++ b/inst/tests/understand_coordinates.R
@@ -1,4 +1,5 @@
 require(shiny)
+require(visNetwork)
 server <- function(input, output) {
   data <- reactive({
     input$go


### PR DESCRIPTION
We needed this for the Debian package (which we call `r-cran-visnetwork`); Let us know if there is a better way to enable running the tests after installation.